### PR TITLE
More commands

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -45,7 +45,8 @@ func (b *Bot) RunCommand(trigger string, channel string) {
 		return
 	}
 
-	command, ok := b.commands[trigger]
+	splitWords := strings.Split(trigger, " ")
+	command, ok := b.commands[splitWords[0]]
 	if !ok {
 		log.Printf("Unrecognized command: %s", trigger)
 		return
@@ -54,14 +55,14 @@ func (b *Bot) RunCommand(trigger string, channel string) {
 	log.Printf("Command: %#v\n", command)
 	b.SendMessage(fmt.Sprintf("Sure, I will !%s", trigger), channel)
 
-	go b.run(trigger, command, channel)
+	go b.run(splitWords, command, channel)
 }
 
-func (b *Bot) run(trigger string, command Command, channel string) {
-	out, err := command.Run()
+func (b *Bot) run(splitWords []string, command Command, channel string) {
+	out, err := command.Run(splitWords)
 	if err != nil {
 		log.Printf("Error %s running: %#v; %s\n", err, command, out)
-		b.SendMessage(fmt.Sprintf("Oops, there was an error in !%s", trigger), channel)
+		b.SendMessage(fmt.Sprintf("Oops, there was an error in !%s", strings.Join(splitWords, " ")), channel)
 		return
 	}
 	log.Printf("Output: %s\n", out)

--- a/command.go
+++ b/command.go
@@ -4,8 +4,11 @@
 package slackbot
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os/exec"
+	"os/user"
 )
 
 type Command interface {
@@ -22,6 +25,87 @@ type ExecCommand struct {
 	description string
 }
 
+// ConfigCommand is a Command that sets some saved state
+type ConfigCommand struct {
+	Desc    string
+	Updater func(c Config) (Config, error)
+}
+
+type ToggleDryRunCommand struct{}
+
+type Config struct {
+	DryRun bool
+	Paused bool
+}
+
+func getConfigPath() (string, error) {
+	u, err := user.Current()
+
+	if err != nil {
+		return "", err
+	}
+
+	return u.HomeDir + "/.keybot", nil
+}
+
+func readConfigOrDefault() Config {
+	defaultConfig := Config{
+		DryRun: true,
+		Paused: false,
+	}
+
+	path, err := getConfigPath()
+
+	if err != nil {
+		return defaultConfig
+	}
+
+	b, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		fmt.Printf("Couldn't read config file:%s\n", err)
+		return defaultConfig
+	}
+
+	var config Config
+	err = json.Unmarshal(b, &config)
+	if err != nil {
+		fmt.Printf("Couldn't read config file:%s\n", err)
+		return defaultConfig
+	}
+
+	return config
+}
+
+func updateConfig(updater func(c Config) (Config, error)) (Config, error) {
+	config := readConfigOrDefault()
+	newConfig, err := updater(config)
+
+	if err != nil {
+		return config, err
+	}
+
+	b, err := json.Marshal(newConfig)
+
+	if err != nil {
+		return config, err
+	}
+
+	path, err := getConfigPath()
+
+	if err != nil {
+		return config, err
+	}
+
+	err = ioutil.WriteFile(path, b, 0644)
+
+	if err != nil {
+		return config, err
+	}
+
+	return newConfig, nil
+}
+
 func NewExecCommand(exec string, args []string, showResult bool, description string) ExecCommand {
 	return ExecCommand{
 		exec:        exec,
@@ -32,15 +116,67 @@ func NewExecCommand(exec string, args []string, showResult bool, description str
 }
 
 func (c ExecCommand) Run() (string, error) {
+	config := readConfigOrDefault()
+
+	if config.DryRun {
+		return fmt.Sprintf("Dry Run: would have ran `%s` with args: %s", c.exec, c.args), nil
+	}
+
 	out, err := exec.Command(c.exec, c.args...).Output()
 	outAsString := fmt.Sprintf("%s", out)
 	return outAsString, err
 }
 
 func (c ExecCommand) ShowResult() bool {
-	return c.showResult
+	config := readConfigOrDefault()
+	return config.DryRun || c.showResult
 }
 
 func (c ExecCommand) Description() string {
 	return c.description
+}
+
+func (c ConfigCommand) Run() (string, error) {
+	config := readConfigOrDefault()
+
+	if config.DryRun {
+		return fmt.Sprintf("Dry Run: %s", c.Description()), nil
+	}
+
+	newConfig, err := updateConfig(c.Updater)
+
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Config is now: %+v", newConfig), nil
+}
+
+func (c ConfigCommand) ShowResult() bool {
+	return true
+}
+
+func (c ConfigCommand) Description() string {
+	return c.Desc
+}
+
+func (c ToggleDryRunCommand) Run() (string, error) {
+	config, err := updateConfig(func(c Config) (Config, error) {
+		c.DryRun = !c.DryRun
+		return c, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Dry Run Value is now: %t", config.DryRun), nil
+}
+
+func (c ToggleDryRunCommand) ShowResult() bool {
+	return true
+}
+
+func (c ToggleDryRunCommand) Description() string {
+	return "Toggles the Dry Run value"
 }

--- a/command.go
+++ b/command.go
@@ -129,6 +129,10 @@ func (c ExecCommand) Run() (string, error) {
 		return fmt.Sprintf("Dry Run: would have ran `%s` with args: %s", c.exec, c.args), nil
 	}
 
+	if config.Paused {
+		return fmt.Sprintf("Paused. But would have ran `%s` with args: %s", c.exec, c.args), nil
+	}
+
 	out, err := exec.Command(c.exec, c.args...).Output()
 	outAsString := fmt.Sprintf("%s", out)
 	return outAsString, err
@@ -137,7 +141,7 @@ func (c ExecCommand) Run() (string, error) {
 // ShowResult decides whether to show the results from the exec
 func (c ExecCommand) ShowResult() bool {
 	config := readConfigOrDefault()
-	return config.DryRun || c.showResult
+	return config.DryRun || config.Paused || c.showResult
 }
 
 // Description describes the command

--- a/command.go
+++ b/command.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 )
 
+// Command is the interface the bot uses to run things
 type Command interface {
 	Run() (string, error)
 	ShowResult() bool // Whether to output result back to channel
@@ -31,8 +32,12 @@ type ConfigCommand struct {
 	Updater func(c Config) (Config, error)
 }
 
+// ToggleDryRunCommand is a special command that toggles dry run state
 type ToggleDryRunCommand struct{}
 
+// Config is the state of the build bot.
+// DryRun will print out what it plans to do without doing it
+// Paused will prevent any builds in the future from running
 type Config struct {
 	DryRun bool
 	Paused bool
@@ -106,6 +111,7 @@ func updateConfig(updater func(c Config) (Config, error)) (Config, error) {
 	return newConfig, nil
 }
 
+// NewExecCommand creates an ExecCommand
 func NewExecCommand(exec string, args []string, showResult bool, description string) ExecCommand {
 	return ExecCommand{
 		exec:        exec,
@@ -115,6 +121,7 @@ func NewExecCommand(exec string, args []string, showResult bool, description str
 	}
 }
 
+// Run runs the exec command
 func (c ExecCommand) Run() (string, error) {
 	config := readConfigOrDefault()
 
@@ -127,15 +134,18 @@ func (c ExecCommand) Run() (string, error) {
 	return outAsString, err
 }
 
+// ShowResult decides whether to show the results from the exec
 func (c ExecCommand) ShowResult() bool {
 	config := readConfigOrDefault()
 	return config.DryRun || c.showResult
 }
 
+// Description describes the command
 func (c ExecCommand) Description() string {
 	return c.description
 }
 
+// Run the config change
 func (c ConfigCommand) Run() (string, error) {
 	config := readConfigOrDefault()
 
@@ -152,14 +162,17 @@ func (c ConfigCommand) Run() (string, error) {
 	return fmt.Sprintf("Config is now: %+v", newConfig), nil
 }
 
+// ShowResult will always show the results of a config change
 func (c ConfigCommand) ShowResult() bool {
 	return true
 }
 
+// Description describes how it will change the config
 func (c ConfigCommand) Description() string {
 	return c.Desc
 }
 
+// Run toggles the dry run state. (Itself is never run under dry run mode)
 func (c ToggleDryRunCommand) Run() (string, error) {
 	config, err := updateConfig(func(c Config) (Config, error) {
 		c.DryRun = !c.DryRun
@@ -173,10 +186,12 @@ func (c ToggleDryRunCommand) Run() (string, error) {
 	return fmt.Sprintf("Dry Run Value is now: %t", config.DryRun), nil
 }
 
+// ShowResult always shows results for toggling dry run
 func (c ToggleDryRunCommand) ShowResult() bool {
 	return true
 }
 
+// Description describes what it does
 func (c ToggleDryRunCommand) Description() string {
 	return "Toggles the Dry Run value"
 }

--- a/config.go
+++ b/config.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os/user"
+	"path/filepath"
 )
 
 // ConfigCommand is a Command that sets some saved state
@@ -31,7 +33,7 @@ func getConfigPath() (string, error) {
 		return "", err
 	}
 
-	return currentUser.HomeDir + "/.keybot", nil
+	return filepath.Join(currentUser.HomeDir, ".keybot"), nil
 }
 
 func readConfigOrDefault() Config {
@@ -49,14 +51,14 @@ func readConfigOrDefault() Config {
 	fileBytes, err := ioutil.ReadFile(path)
 
 	if err != nil {
-		fmt.Printf("Couldn't read config file:%s\n", err)
+		log.Printf("Couldn't read config file:%s\n", err)
 		return defaultConfig
 	}
 
 	var config Config
 	err = json.Unmarshal(fileBytes, &config)
 	if err != nil {
-		fmt.Printf("Couldn't read config file:%s\n", err)
+		log.Printf("Couldn't read config file:%s\n", err)
 		return defaultConfig
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,120 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package slackbot
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os/user"
+)
+
+// ConfigCommand is a Command that sets some saved state
+type ConfigCommand struct {
+	Desc    string
+	Updater func(c Config) (Config, error)
+}
+
+// Config is the state of the build bot.
+// DryRun will print out what it plans to do without doing it
+// Paused will prevent any builds in the future from running
+type Config struct {
+	DryRun bool
+	Paused bool
+}
+
+func getConfigPath() (string, error) {
+	currentUser, err := user.Current()
+
+	if err != nil {
+		return "", err
+	}
+
+	return currentUser.HomeDir + "/.keybot", nil
+}
+
+func readConfigOrDefault() Config {
+	defaultConfig := Config{
+		DryRun: true,
+		Paused: false,
+	}
+
+	path, err := getConfigPath()
+
+	if err != nil {
+		return defaultConfig
+	}
+
+	fileBytes, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		fmt.Printf("Couldn't read config file:%s\n", err)
+		return defaultConfig
+	}
+
+	var config Config
+	err = json.Unmarshal(fileBytes, &config)
+	if err != nil {
+		fmt.Printf("Couldn't read config file:%s\n", err)
+		return defaultConfig
+	}
+
+	return config
+}
+
+func updateConfig(updater func(c Config) (Config, error)) (Config, error) {
+	config := readConfigOrDefault()
+	newConfig, err := updater(config)
+
+	if err != nil {
+		return config, err
+	}
+
+	b, err := json.Marshal(newConfig)
+
+	if err != nil {
+		return config, err
+	}
+
+	path, err := getConfigPath()
+
+	if err != nil {
+		return config, err
+	}
+
+	err = ioutil.WriteFile(path, b, 0644)
+
+	if err != nil {
+		return config, err
+	}
+
+	return newConfig, nil
+}
+
+// Run the config change
+func (c ConfigCommand) Run(_ []string) (string, error) {
+	config := readConfigOrDefault()
+
+	if config.DryRun {
+		return fmt.Sprintf("Dry Run: %s", c.Description()), nil
+	}
+
+	newConfig, err := updateConfig(c.Updater)
+
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Config is now: %+v", newConfig), nil
+}
+
+// ShowResult will always show the results of a config change
+func (c ConfigCommand) ShowResult() bool {
+	return true
+}
+
+// Description describes how it will change the config
+func (c ConfigCommand) Description() string {
+	return c.Desc
+}

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -5,8 +5,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/keybase/slackbot"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -39,6 +42,7 @@ func kingpinHandler(args []string) (string, error) {
 
 	if err != nil {
 		log.Printf("Error in parsing command: %s. got %s", args, err)
+		io.WriteString(stringBuffer, fmt.Sprintf("I don't know what you mean by `%s`.\nError: `%s`\nHere's my usage:\n\n", strings.Join(args, " "), err.Error()))
 		// Print out help page if there was an error parsing command
 		app.Usage([]string{})
 	}

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -21,6 +21,31 @@ func main() {
 		log.Fatal(err)
 	}
 
+	bot.AddCommand("pause", slackbot.ConfigCommand{
+		"Pause any future builds",
+		func(c slackbot.Config) (slackbot.Config, error) {
+			c.Paused = true
+			return c, nil
+		},
+	})
+
+	bot.AddCommand("start", slackbot.ConfigCommand{
+		"Contine any future builds",
+		func(c slackbot.Config) (slackbot.Config, error) {
+			c.Paused = false
+			return c, nil
+		},
+	})
+
+	bot.AddCommand("ls config", slackbot.ConfigCommand{
+		"List current config",
+		func(c slackbot.Config) (slackbot.Config, error) {
+			return c, nil
+		},
+	})
+
+	bot.AddCommand("toggle dryrun", slackbot.ToggleDryRunCommand{})
+
 	bot.AddCommand("build", slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build"))
 	bot.AddCommand("build cancel", slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.prerelease"}, false, "Cancel a running build"))
 	bot.AddCommand("build test", slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.test"}, false, "Test the build"))

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -4,11 +4,73 @@
 package main
 
 import (
+	"bytes"
 	"log"
 	"os"
 
 	"github.com/keybase/slackbot"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
+
+func setEnv(name string, val string) error {
+	_, err := slackbot.NewExecCommand("/bin/launchctl", []string{"setenv", name, val}, false, "Set the env").Run([]string{})
+	return err
+}
+
+func kingpinHandler(args []string) (string, error) {
+	app := kingpin.New("slackbot", "Command parser for slackbot")
+	app.Terminate(nil)
+	stringBuffer := new(bytes.Buffer)
+	app.Writer(stringBuffer)
+
+	build := app.Command("build", "Build things")
+
+	clientCommit := build.Flag("client-commit", "Build a specific client commit hash").String()
+	kbfsCommit := build.Flag("kbfs-commit", "Build a specific kbfs commit hash").String()
+
+	buildPlease := build.Command("please", "Start a build")
+	buildTest := build.Command("test", "Start a test build")
+	cancel := build.Command("cancel", "Cancel any existing builds. commit flags don't affect this.")
+
+	cmd, err := app.Parse(args)
+
+	if stringBuffer.Len() > 0 {
+		return stringBuffer.String(), nil
+	}
+
+	if err != nil {
+		return err.Error(), nil
+	}
+
+	buildStart := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build")
+	buildStop := slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.prerelease"}, false, "Cancel a running build")
+	buildStartTest := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.test"}, false, "Test the build")
+
+	emptyArgs := []string{}
+
+	switch cmd {
+	case buildPlease.FullCommand():
+		err = setEnv("CLIENT_COMMIT", *clientCommit)
+
+		if err != nil {
+			return "", err
+		}
+
+		err = setEnv("KBFS_COMMIT", *kbfsCommit)
+
+		if err != nil {
+			return "", err
+		}
+
+		return buildStart.Run(emptyArgs)
+	case cancel.FullCommand():
+		return buildStop.Run(emptyArgs)
+	case buildTest.FullCommand():
+		return buildStartTest.Run(emptyArgs)
+	}
+
+	return cmd, nil
+}
 
 func main() {
 	token := os.Getenv("SLACK_TOKEN")
@@ -30,25 +92,23 @@ func main() {
 	})
 
 	bot.AddCommand("start", slackbot.ConfigCommand{
-		"Contine any future builds",
+		"Continue any future builds",
 		func(c slackbot.Config) (slackbot.Config, error) {
 			c.Paused = false
 			return c, nil
 		},
 	})
 
-	bot.AddCommand("ls config", slackbot.ConfigCommand{
+	bot.AddCommand("ls-config", slackbot.ConfigCommand{
 		"List current config",
 		func(c slackbot.Config) (slackbot.Config, error) {
 			return c, nil
 		},
 	})
 
-	bot.AddCommand("toggle dryrun", slackbot.ToggleDryRunCommand{})
+	bot.AddCommand("toggle-dryrun", slackbot.ToggleDryRunCommand{})
 
-	bot.AddCommand("build", slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build"))
-	bot.AddCommand("build cancel", slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.prerelease"}, false, "Cancel a running build"))
-	bot.AddCommand("build test", slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.test"}, false, "Test the build"))
+	bot.AddCommand("build", slackbot.FuncCommand{"Build all the things!", kingpinHandler})
 
 	bot.AddCommand("restart", slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.keybot"}, false, "Restart the bot"))
 

--- a/launchd/keybase.keybot.build.plist
+++ b/launchd/keybase.keybot.build.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>keybase.keybot</string>
+    <string>keybase.keybot.build</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>GOPATH</key>

--- a/launchd/keybase.keybot.build.plist
+++ b/launchd/keybase.keybot.build.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>keybase.keybot</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GOPATH</key>
+        <string></string>
+        <key>SLACK_TOKEN</key>
+        <string></string>
+        <key>SLACK_CHANNEL</key>
+        <string></string>
+        <key>PATH</key>
+        <string>/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>slackbot/send/send.sh</string>
+        <string>!build</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Weekday</key>
+            <integer>1</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Weekday</key>
+            <integer>2</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Weekday</key>
+            <integer>3</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Weekday</key>
+            <integer>4</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>9</integer>
+            <key>Weekday</key>
+            <integer>5</integer>
+        </dict>
+    </array>
+    <key>StandardErrorPath</key>
+    <string>/Users/test/Library/Logs/keybase.keybot.build.log</string>
+    <key>StandardOutPath</key>
+    <string>/Users/test/Library/Logs/keybase.keybot.build.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
@gabriel 

Created 2 new Commands.

Configs are saved under `$HOME/.keybot` as json

### ConfigCommand
A command that changes a value in the config.
It takes an updater function `Config -> (Config, error)`
and a description.

### ToggleDryRunCommand
Since toggling dry run can't run in dry run, I made a separate command for it


We have dry run that makes everything powerless, I think this is useful for testing commands without having to worry about what will happen.

Paused Prevents any exec commands from doing anything.

### Build

`!build please` will build the app. You can supply --client-commit and --kbfs-commit to specify which commit to build from.

`!build cancel` cancels any active build

`!build test` builds a test build, you can supply the same --cllient-commit and --kbfs-commit flags