### PR TITLE
Add support for running a Linux bot

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -61,7 +61,7 @@ func (b *Bot) run(args []string, command Command, channel string) {
 	out, err := command.Run(args)
 	if err != nil {
 		log.Printf("Error %s running: %#v; %s\n", err, command, out)
-		b.SendMessage(fmt.Sprintf("Oops, there was an error in !%s", strings.Join(args, " ")), channel)
+		b.SendMessage(fmt.Sprintf("Oops, there was an error in %q:\n%s", strings.Join(args, " "), SlackBlockQuote(out)), channel)
 		return
 	}
 	log.Printf("Output: %s\n", out)
@@ -146,4 +146,11 @@ Loop:
 			}
 		}
 	}
+}
+
+func SlackBlockQuote(s string) string {
+	if !strings.HasSuffix(s, "\n") {
+		s += "\n"
+	}
+	return "```\n" + s + "```"
 }

--- a/command.go
+++ b/command.go
@@ -54,7 +54,7 @@ func (c ExecCommand) Run(_ []string) (string, error) {
 		return fmt.Sprintf("I'm paused so I can't do that, but I would have ran `%s` with args: %s", c.exec, c.args), nil
 	}
 
-	out, err := exec.Command(c.exec, c.args...).Output()
+	out, err := exec.Command(c.exec, c.args...).CombinedOutput()
 	outAsString := fmt.Sprintf("%s", out)
 	return outAsString, err
 }

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -50,7 +50,7 @@ func kingpinHandler(args []string) (string, error) {
 	}
 
 	if stringBuffer.Len() > 0 {
-		return fmt.Sprintf("```\n%s\n```", stringBuffer.String()), nil
+		return slackbot.SlackBlockQuote(stringBuffer.String()), nil
 	}
 
 	buildStart := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build")

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setEnv(name string, val string) error {
-	_, err := slackbot.NewExecCommand("/bin/launchctl", []string{"setenv", name, val}, false, "Set the env").Run([]string{})
+	_, err := setEnvCommand(name, val).Run([]string{})
 	return err
 }
 
@@ -53,11 +53,6 @@ func kingpinHandler(args []string) (string, error) {
 		return slackbot.SlackBlockQuote(stringBuffer.String()), nil
 	}
 
-	buildStart := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build")
-	buildStop := slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.prerelease"}, false, "Cancel a running build")
-	buildStartTest := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.test"}, false, "Test the build")
-	buildAndroidCmd := slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.android.release"}, false, "Perform an alpha build")
-
 	emptyArgs := []string{}
 
 	switch cmd {
@@ -74,13 +69,13 @@ func kingpinHandler(args []string) (string, error) {
 			return "", err
 		}
 
-		return buildStart.Run(emptyArgs)
+		return buildStartCommand().Run(emptyArgs)
 
 	case buildAndroid.FullCommand():
-		return buildAndroidCmd.Run(emptyArgs)
+		return buildAndroidCommand().Run(emptyArgs)
 
 	case cancel.FullCommand():
-		return buildStop.Run(emptyArgs)
+		return buildStopCommand().Run(emptyArgs)
 	case buildTest.FullCommand():
 		err = setEnv("CLIENT_COMMIT", *testClientCommit)
 
@@ -94,7 +89,7 @@ func kingpinHandler(args []string) (string, error) {
 			return "", err
 		}
 
-		return buildStartTest.Run(emptyArgs)
+		return buildStartTestCommand().Run(emptyArgs)
 	}
 
 	return cmd, nil
@@ -138,7 +133,7 @@ func main() {
 
 	bot.AddCommand("build", slackbot.FuncCommand{"Build all the things!", kingpinHandler})
 
-	bot.AddCommand("restart", slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.keybot"}, false, "Restart the bot"))
+	bot.AddCommand("restart", restartCommand())
 
 	bot.AddCommand("date", slackbot.NewExecCommand("/bin/date", nil, true, "Show the current date"))
 

--- a/keybot/platform_darwin.go
+++ b/keybot/platform_darwin.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package main
+
+import (
+	"github.com/keybase/slackbot"
+)
+
+func setEnvCommand(name string, val string) slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"setenv", name, val}, false, "Set the env")
+}
+
+func buildStartCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease"}, false, "Perform a build")
+}
+
+func buildStopCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.prerelease"}, false, "Cancel a running build")
+}
+
+func buildStartTestCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.test"}, false, "Test the build")
+}
+
+func buildAndroidCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.android.release"}, false, "Perform an alpha build")
+}
+
+func restartCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.keybot"}, false, "Restart the bot")
+}

--- a/keybot/platform_linux.go
+++ b/keybot/platform_linux.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package main
+
+import (
+	"github.com/keybase/slackbot"
+	"log"
+)
+
+func setEnvCommand(name string, val string) slackbot.ExecCommand {
+	log.Printf("WARNING: setEnvCommand(%q, %q) is a NO-OP on Linux", name, val)
+	return slackbot.NewExecCommand("true", []string{}, false, "Set the env")
+}
+
+func buildStartCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, false, "Perform a build")
+}
+
+func buildStopCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, false, "Cancel a running build")
+}
+
+func buildStartTestCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, false, "Test the build")
+}
+
+func buildAndroidCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, false, "Perform an alpha build")
+}
+
+func restartCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, false, "Restart the bot")
+}


### PR DESCRIPTION
- Have KeyBot answer to its own name, as determined by it's Slack session. So where before I would've typed `!build please` for a Mac build, I would now type `!keybot build please` for Mac and `!tuxbot build please` for Linux.
- Capture both stdout and stderr from exec commands, and send the full contents of errors as Slack messages. (I might regret this if they get very long.)
- Factor out the `launchd` commands into `platform_darwin.go`.
- Define `platform_linux.go`, with some stubs. Will flesh these out in the next PR.

r? @gabriel @MarcoPolo