### PR TITLE
use the new bot-name-included command syntax in the OSX build jobs

### DIFF
--- a/launchd/keybase.keybot.build.android.plist
+++ b/launchd/keybase.keybot.build.android.plist
@@ -19,7 +19,7 @@
     <array>
         <string>/bin/bash</string>
         <string>/Users/test/go/src/github.com/keybase/slackbot/send/send.sh</string>
-        <string>!build android</string>
+        <string>!keybot build android</string>
     </array>
     <key>StartCalendarInterval</key>
     <array>

--- a/launchd/keybase.keybot.build.plist
+++ b/launchd/keybase.keybot.build.plist
@@ -19,7 +19,7 @@
     <array>
         <string>/bin/bash</string>
         <string>/Users/test/go/src/github.com/keybase/slackbot/send/send.sh</string>
-        <string>!build please</string>
+        <string>!keybot build please</string>
     </array>
     <key>StartCalendarInterval</key>
     <array>


### PR DESCRIPTION
In fff0977efc545cb88c32991431fb32252333efcd I made keybot look for its
own name in command prefixes. When this change rolls out to our Mac
build machine, it will break existing jobs, which rely on the old
syntax.

r? @gabriel 

I just realized that if we push slackbot to the Mac Mini as is, we'll break the Mac build timers. This is an example of how to fix them. We could also consider giving the Mac bot a more Mac-specific name. Or we could consider adding some configuration to make Keybot continue to use non-prefixed commands. Let me know what you prefer, Gabriel.