### PR TITLE
Allow promoting a specific build to public

### DIFF
--- a/keybot/main.go
+++ b/keybot/main.go
@@ -29,6 +29,7 @@ func kingpinHandler(args []string) (string, error) {
 	build := app.Command("build", "Build things")
 	buildPlease := build.Command("please", "Start a build")
 	buildTest := build.Command("test", "Start a test build")
+
 	buildAndroid := build.Command("android", "Start an android build")
 
 	clientCommit := buildPlease.Flag("client-commit", "Build a specific client commit hash").String()

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -29,7 +29,6 @@ func kingpinHandler(args []string) (string, error) {
 	build := app.Command("build", "Build things")
 	buildPlease := build.Command("please", "Start a build")
 	buildTest := build.Command("test", "Start a test build")
-
 	buildAndroid := build.Command("android", "Start an android build")
 
 	clientCommit := buildPlease.Flag("client-commit", "Build a specific client commit hash").String()
@@ -37,6 +36,10 @@ func kingpinHandler(args []string) (string, error) {
 
 	testClientCommit := buildTest.Flag("client-commit", "Build a specific client commit hash").String()
 	testKbfsCommit := buildTest.Flag("kbfs-commit", "Build a specific kbfs commit hash").String()
+
+	release := app.Command("release", "Release things")
+	releasePromote := release.Command("promote", "Promote a release to public")
+	releaseToPromote := release.Arg("release-to-promote", "Promote a specific release to public immediately").Required().String()
 
 	cancel := build.Command("cancel", "Cancel any existing builds")
 
@@ -76,6 +79,14 @@ func kingpinHandler(args []string) (string, error) {
 
 	case cancel.FullCommand():
 		return buildStopCommand().Run(emptyArgs)
+
+	case releasePromote.FullCommand():
+		err = setEnv("RELEASE_TO_PROMOTE", *releaseToPromote)
+		if err != nil {
+			return "", err
+		}
+		return releasePromoteCommand().Run(emptyArgs)
+
 	case buildTest.FullCommand():
 		err = setEnv("CLIENT_COMMIT", *testClientCommit)
 

--- a/keybot/platform_darwin.go
+++ b/keybot/platform_darwin.go
@@ -30,3 +30,7 @@ func buildAndroidCommand() slackbot.ExecCommand {
 func restartCommand() slackbot.ExecCommand {
 	return slackbot.NewExecCommand("/bin/launchctl", []string{"stop", "keybase.keybot"}, false, "Restart the bot")
 }
+
+func releasePromoteCommand() slackbot.ExecCommand {
+	return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.promotearelease"}, false, "Promote a specific release to public")
+}

--- a/keybot/platform_linux.go
+++ b/keybot/platform_linux.go
@@ -32,3 +32,7 @@ func buildAndroidCommand() slackbot.ExecCommand {
 func restartCommand() slackbot.ExecCommand {
 	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, true, "Restart the bot")
 }
+
+func releasePromoteCommand(release string) slackbot.ExecCommand {
+	return slackbot.NewExecCommand("bash", []string{"-c", "echo not implemented; false"}, true, "Promote a specific release to public")
+}


### PR DESCRIPTION
@gabriel @oconnor663 

This comes together with a PR I'm about to open in keybase/release.  I don't have access to the Mac Mini, and I don't see the launchctl services checked in anywhere, so I'll need some help with that.  But the idea is that `keybase.prerelease.promotearelease` exists and ultimately calls `release promote-a-release --release [release-to-promote] --bucket-name prerelease.keybase.io --platform darwin`.
