### PR TITLE
Fix parse context check

### DIFF
--- a/keybot/main.go
+++ b/keybot/main.go
@@ -23,6 +23,13 @@ func setEnv(name string, val string) error {
 	return err
 }
 
+func isParseContextValid(app *kingpin.Application, args []string) error {
+	if pcontext, perr := app.ParseContext(args); pcontext == nil {
+		return perr
+	}
+	return nil
+}
+
 func kingpinHandler(args []string) (string, error) {
 	app := kingpin.New("slackbot", "Command parser for slackbot")
 	app.Terminate(nil)
@@ -51,9 +58,10 @@ func kingpinHandler(args []string) (string, error) {
 	cancelWindows := cancel.Command("windows", "Cancel last windows build")
 	cancelWindowsQueueId := cancelWindows.Arg("quid", "queue id of build to stop").Required().String()
 
-	// Make sure context parses otherwise showing Usage on error will fail later
-	if _, perr := app.ParseContext(args); perr != nil {
-		return "", perr
+	// Make sure context is valid otherwise showing Usage on error will fail later.
+	// This is a workaround for a kingpin bug.
+	if err := isParseContextValid(app, args); err != nil {
+		return "", err
 	}
 
 	cmd, err := app.Parse(args)

--- a/keybot/main_darwin_test.go
+++ b/keybot/main_darwin_test.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin
+
+package main
+
+import "testing"
+
+func TestBuildPlease(t *testing.T) {
+	out, err := kingpinHandler([]string{"build", "please"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease]" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}
+
+func TestPromoteRelease(t *testing.T) {
+	out, err := kingpinHandler([]string{"release", "promote", "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease.promotearelease]" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/keybase/slackbot"
@@ -33,6 +34,16 @@ func TestPromoteRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease.promotearelease]" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}
+
+func TestInvalidUsage(t *testing.T) {
+	out, err := kingpinHandler([]string{"release", "oops"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "```\nI don't know what you mean by") {
 		t.Errorf("Unexpected output: %s", out)
 	}
 }

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -17,10 +17,22 @@ func TestAddCommands(t *testing.T) {
 	addCommands(bot)
 }
 
-func TestKinpinHandler(t *testing.T) {
+func TestBuildPlease(t *testing.T) {
 	out, err := kingpinHandler([]string{"build", "please"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("out: %s", out)
+	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease]" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}
+
+func TestPromoteRelease(t *testing.T) {
+	out, err := kingpinHandler([]string{"release", "promote", "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease.promotearelease]" {
+		t.Errorf("Unexpected output: %s", out)
+	}
 }

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -18,26 +18,6 @@ func TestAddCommands(t *testing.T) {
 	addCommands(bot)
 }
 
-func TestBuildPlease(t *testing.T) {
-	out, err := kingpinHandler([]string{"build", "please"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease]" {
-		t.Errorf("Unexpected output: %s", out)
-	}
-}
-
-func TestPromoteRelease(t *testing.T) {
-	out, err := kingpinHandler([]string{"release", "promote", "1.2.3"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out != "Dry Run: Doing that would run `/bin/launchctl` with args: [start keybase.prerelease.promotearelease]" {
-		t.Errorf("Unexpected output: %s", out)
-	}
-}
-
 func TestInvalidUsage(t *testing.T) {
 	out, err := kingpinHandler([]string{"release", "oops"})
 	if err != nil {


### PR DESCRIPTION
Fix invalid usage showing help. Don't error if parse context fails... error if the parse context is nil.

Also make more tests.