### PR TITLE
stop running prerelease.sh in its own service

### DIFF
--- a/systemd/keybase.prerelease.service
+++ b/systemd/keybase.prerelease.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Run the Keybase prerelease Linux build
-
-[Service]
-Type=oneshot
-ExecStart=/home/keybasebuild/slackbot/systemd/prerelease.sh
-
-[Install]
-WantedBy=default.target

--- a/tuxbot/main_test.go
+++ b/tuxbot/main_test.go
@@ -13,7 +13,7 @@ func TestBuildLinux(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "Dry Run: Doing that would run `systemctl --user start keybase.prerelease.service`" {
+	if out != "Dry Run: Doing that would run `prerelease.sh`" {
 		t.Errorf("Unexpected output: %s", out)
 	}
 }


### PR DESCRIPTION
The main benefit to doing that was capturing logs, but we already get
that because keybot itself is running as a service. Get rid of this
unnecessary extra piece of indirection (and setup).

r? @gabriel 