### PR TITLE
Add a smoketest command to Slackbot, and launchd plist

### DIFF
--- a/keybot/main.go
+++ b/keybot/main.go
@@ -128,7 +128,7 @@ func kingpinKeybotHandler(channel string, args []string) (string, error) {
 		if err = setDarwinEnv("SMOKETEST_BUILD_ENABLE", buildEnable); err != nil {
 			return "", err
 		}
-		return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.smoketestbuild"}, false, "Start or stop smoketesting a given build").Run("", emptyArgs)
+		return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.smoketest"}, false, "Start or stop smoketesting a given build").Run("", emptyArgs)
 	}
 	return cmd, nil
 }

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -121,7 +121,11 @@ func kingpinKeybotHandler(channel string, args []string) (string, error) {
 		if err = setDarwinEnv("SMOKETEST_BUILD_PLATFORM", *smoketestBuildPlatform); err != nil {
 			return "", err
 		}
-		if err = setDarwinEnv("SMOKETEST_BUILD_ENABLE", *smoketestBuildEnable); err != nil {
+		buildEnable := "true"
+		if !*smoketestBuildEnable {
+			buildEnable = "false"
+		}
+		if err = setDarwinEnv("SMOKETEST_BUILD_ENABLE", buildEnable); err != nil {
 			return "", err
 		}
 		return slackbot.NewExecCommand("/bin/launchctl", []string{"start", "keybase.prerelease.smoketestbuild"}, false, "Start or stop smoketesting a given build").Run("", emptyArgs)

--- a/launchd/keybase.prerelease.smoketest.plist
+++ b/launchd/keybase.prerelease.smoketest.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>keybase.prerelease.smoketest</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GOPATH</key>
+        <string>/Users/test/go</string>
+        <key>GITHUB_TOKEN</key>
+        <string></string>
+        <key>SLACK_TOKEN</key>
+        <string></string>
+        <key>SLACK_CHANNEL</key>
+        <string></string>
+        <key>AWS_ACCESS_KEY</key>
+        <string></string>
+        <key>AWS_SECRET_KEY</key>
+        <string></string>
+        <key>PATH</key>
+        <string>/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin</string>
+        <key>LOG_PATH</key>
+        <string>/Users/test/Library/Logs/keybase.prerelease.smoketest.log</string>
+        <key>SCRIPT_PATH</key>
+        <string>/Users/test/go/src/github.com/keybase/slackbot/launchd/smoketest.sh</string>
+        <key>PLATFORM</key>
+        <string>darwin</string>
+        <key>COMMAND</key>
+        <string>build darwin</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/test/go/src/github.com/keybase/slackbot/launchd/run.sh</string>
+    </array>
+    <key>StandardErrorPath</key>
+    <string>/Users/test/Library/Logs/keybase.prerelease.smoketest.log</string>
+    <key>StandardOutPath</key>
+    <string>/Users/test/Library/Logs/keybase.prerelease.smoketest.log</string>
+</dict>
+</plist>

--- a/launchd/smoketest.sh
+++ b/launchd/smoketest.sh
@@ -5,20 +5,11 @@ set -e -u -o pipefail # Fail on error
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "$dir"
 
-logpath=${LOG_PATH:-}
-
 client_dir="$GOPATH/src/github.com/keybase/client"
 
 echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
-
-err_report() {
-  url=`$release_bin save-log --bucket-name=prerelease.keybase.io --path=$logpath --noerr`
-  "$client_dir/packaging/slack/send.sh" "Error see $url"
-}
-
-trap 'err_report $LINENO' ERR
 
 if [ -n "$SMOKETEST_BUILD_A" ] && [ -n "$SMOKETEST_BUILD_PLATFORM" ] && [ -n "$SMOKETEST_BUILD_ENABLE" ]; then
   "$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE"

--- a/launchd/smoketestbuild.sh
+++ b/launchd/smoketestbuild.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$dir"
+
+logpath=${LOG_PATH:-}
+
+client_dir="$GOPATH/src/github.com/keybase/client"
+
+echo "Loading release tool"
+"$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
+release_bin="$GOPATH/bin/release"
+
+err_report() {
+  url=`$release_bin save-log --bucket-name=prerelease.keybase.io --path=$logpath --noerr`
+  "$client_dir/packaging/slack/send.sh" "Error see $url"
+}
+
+trap 'err_report $LINENO' ERR
+
+if [ -n "$SMOKETEST_BUILD_A" ] && [ -n "$SMOKETEST_BUILD_PLATFORM" ] && [ -n "$SMOKETEST_BUILD_ENABLE" ]; then
+  "$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE"
+  "$client_dir/packaging/slack/send.sh" "Successfully set enable to $SMOKETEST_BUILD_ENABLE for release $SMOKETEST_BUILD_A."
+else
+  "$client_dir/packaging/slack/send.sh" "Error: Missing environment variables in smoketest command."
+fi


### PR DESCRIPTION
r? @gabriel  CC @oconnor663 

Here's an untested Slackbot PR for adding the smoketest command, which is backed by ./release set-build-in-testing.

The flow is convoluted -- the command sets envvars, then it calls a plist, which calls a shell script, which converts the envvars into command line switches, and calls ./release with the command line switches.  This matches the existing `promotearelease` setup.