### PR TITLE
smoketesting: support new max_testers API field

### DIFF
--- a/keybot/main.go
+++ b/keybot/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"log"
+	"strconv"
 
 	"github.com/keybase/slackbot"
 	"github.com/keybase/slackbot/cli"
@@ -46,9 +47,10 @@ func kingpinKeybotHandler(channel string, args []string) (string, error) {
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()
 
 	smoketestBuild := app.Command("smoketest", "Set the smoke testing status of a build")
-	smoketestBuildA := smoketestBuild.Arg("build-a", "The first of the two IDs comprising the new build").Required().String()
-	smoketestBuildPlatform := smoketestBuild.Arg("platform", "The build's platform (darwin, linux, windows)").Required().String()
-	smoketestBuildEnable := smoketestBuild.Arg("enable", "Whether smoketesting should be enabled").Required().Bool()
+	smoketestBuildA := smoketestBuild.Flag("build-a", "The first of the two IDs comprising the new build").Required().String()
+	smoketestBuildPlatform := smoketestBuild.Flag("platform", "The build's platform (darwin, linux, windows)").Required().String()
+	smoketestBuildEnable := smoketestBuild.Flag("enable", "Whether smoketesting should be enabled").Required().Bool()
+	smoketestBuildMaxTesters := smoketestBuild.Flag("max-testers", "Max number of testers for this build").Required().Int()
 
 	buildWindows := build.Command("windows", "Start a windows build")
 	testWindows := test.Command("windows", "Start a windows test build")
@@ -119,6 +121,9 @@ func kingpinKeybotHandler(channel string, args []string) (string, error) {
 			return "", err
 		}
 		if err = setDarwinEnv("SMOKETEST_PLATFORM", *smoketestBuildPlatform); err != nil {
+			return "", err
+		}
+		if err = setDarwinEnv("SMOKETEST_MAX_TESTERS", strconv.Itoa(*smoketestBuildMaxTesters)); err != nil {
 			return "", err
 		}
 		buildEnable := "true"

--- a/launchd/smoketest.sh
+++ b/launchd/smoketest.sh
@@ -11,9 +11,5 @@ echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
-if [ -n "$SMOKETEST_BUILD_A" ] && [ -n "$SMOKETEST_PLATFORM" ] && [ -n "$SMOKETEST_BUILD_ENABLE" ] && [ -n "$SMOKETEST_MAX_TESTERS"; then
-  "$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE --max-testers="$SMOKETEST_MAX_TESTERS"
-  "$client_dir/packaging/slack/send.sh" "Successfully set enable to $SMOKETEST_BUILD_ENABLE for release $SMOKETEST_BUILD_A."
-else
-  "$client_dir/packaging/slack/send.sh" "Error: Missing environment variables in smoketest command."
-fi
+"$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE --max-testers="$SMOKETEST_MAX_TESTERS"
+"$client_dir/packaging/slack/send.sh" "Successfully set enable to $SMOKETEST_BUILD_ENABLE for release $SMOKETEST_BUILD_A."

--- a/launchd/smoketest.sh
+++ b/launchd/smoketest.sh
@@ -11,8 +11,8 @@ echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
-if [ -n "$SMOKETEST_BUILD_A" ] && [ -n "$SMOKETEST_PLATFORM" ] && [ -n "$SMOKETEST_BUILD_ENABLE" ]; then
-  "$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE"
+if [ -n "$SMOKETEST_BUILD_A" ] && [ -n "$SMOKETEST_PLATFORM" ] && [ -n "$SMOKETEST_BUILD_ENABLE" ] && [ -n "$SMOKETEST_MAX_TESTERS"; then
+  "$release_bin" set-build-in-testing --build-a="$SMOKETEST_BUILD_A" --platform="$SMOKETEST_PLATFORM" --enable="$SMOKETEST_BUILD_ENABLE --max-testers="$SMOKETEST_MAX_TESTERS"
   "$client_dir/packaging/slack/send.sh" "Successfully set enable to $SMOKETEST_BUILD_ENABLE for release $SMOKETEST_BUILD_A."
 else
   "$client_dir/packaging/slack/send.sh" "Error: Missing environment variables in smoketest command."


### PR DESCRIPTION
r? @oconnor663 @gabriel 

Also, switch from args to flags (using args was unintended), i.e. from:
```
!keybot smoketest 1.0.17-20161014201911+2f2072e darwin 1 15
```
to:
```
!keybot smoketest --build-a 1.0.17-20161014201911+2f2072e --platform darwin --enable 1 --max-testers 15
```