### PR TITLE
Enable secure Jenkins build control for Windows

### DIFF
--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -139,6 +139,7 @@ func doJenkinsPost(buildurl string) (*http.Response, error) {
 func StartBuild(clientRev string, kbfsRev string, updateChannel string) (string, error) {
 	u, err := url.Parse(jenkinsURL + "/job/" + jenkinsJobName + "/buildWithParameters")
 	urlValues := url.Values{}
+	urlValues.Add("SlackBot", "true")
 	if clientRev != "" {
 		urlValues.Add("ClientRevision", clientRev)
 	}

--- a/jenkins/main/main.go
+++ b/jenkins/main/main.go
@@ -6,28 +6,37 @@ package main
 import (
 	"flag"
 	"log"
+	"time"
 
 	"github.com/keybase/slackbot/jenkins"
 )
 
 func main() {
 	var f struct {
-		action             string
-		clientRev          string
-		kbfsRev            string
-		jsonUpdateFilename string
+		action        string
+		clientRev     string
+		kbfsRev       string
+		updateChannel string
+		crumb         string
 	}
 	flag.StringVar(&f.action, "action", "build", "Action")
 	flag.StringVar(&f.clientRev, "client-rev", "", "Client commit")
 	flag.StringVar(&f.kbfsRev, "kbfs-rev", "", "KBFS commit")
-	flag.StringVar(&f.jsonUpdateFilename, "json", "", "JSON update filename")
+	flag.StringVar(&f.crumb, "crumb", "", "Jenkins Crumb")
+	flag.StringVar(&f.updateChannel, "update-channel", "Test", "update channel: Test, Smoke, SmokeCI (default)")
 	flag.Parse()
+
+	if f.crumb != "" {
+		jenkins.SetLastCrumb(jenkins.CrumbResult{Crumb: f.crumb, Time: time.Now()})
+	}
 
 	switch f.action {
 	case "stop":
 		jenkins.StopBuild(flag.Arg(0))
 	case "build":
-		res, _ := jenkins.StartBuild(f.clientRev, f.kbfsRev, f.jsonUpdateFilename)
+		res, _ := jenkins.StartBuild(f.clientRev, f.kbfsRev, f.updateChannel)
 		log.Printf("Started: %s\n", res)
 	}
+	crumb := jenkins.GetLastCrumb()
+	log.Printf("Crumb: %s\n", crumb.Crumb)
 }

--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ func (k *keybot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 	build := app.Command("build", "Build things")
 
 	cancel := app.Command("cancel", "Cancel")
-	cancelLabel := cancel.Arg("label", "Launchd job label").Required().String()
+	cancelLabel := cancel.Arg("label", "Launchd job label").String()
 	cancelWin := cancel.Flag("windows", "Specify Windows build (label = jenkins job)").Bool()
 
 	buildAndroid := build.Command("android", "Start an android build")
@@ -81,6 +82,8 @@ func (k *keybot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 				out = out + " for " + *cancelLabel
 			}
 			return out, nil
+		} else if *cancelLabel == "" {
+			return "Label required for cancel", errors.New("Label required for cancel")
 		}
 		return launchd.Stop(*cancelLabel)
 	case buildAndroid.FullCommand():
@@ -173,7 +176,6 @@ func (k *keybot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 		}
 		return runScript(bot, channel, env, script)
 
-	// Windows
 	case buildWindows.FullCommand():
 		return jenkins.StartBuild(*buildWindowsCientCommit, *buildWindowsKbfsCommit, *buildWindowsUpdateChannel)
 	}


### PR DESCRIPTION
@jzila let me add a slackbot account on Jenkins, the credentials of which must be set in the environment with JENKINS_WINDOWS_USERNAME and JENKINS_WINDOWS_PASSWORD.

This makes building and cancelling work, but I'm not sure about the other commands. Would it be better to have a winbot? 

Also still figuring out how to have Jenkins notify Slack via groovy script.

@gabriel @chrisnojima 