### PR TITLE
Have winbot do automatic daily builds

### DIFF
--- a/keybot/main.go
+++ b/keybot/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 
 	"github.com/keybase/slackbot"
 	"github.com/keybase/slackbot/launchd"
@@ -99,8 +98,6 @@ func main() {
 	bot.SetHelp(bot.HelpMessage() + "\n\n" + ext.Help(bot))
 
 	bot.SendMessage("I'm running.", os.Getenv("SLACK_CHANNEL"))
-	if runtime.GOOS == "windows" {
-		ext.Run(bot, os.Getenv("SLACK_CHANNEL"), []string{"startAutoTimer"})
-	}
+
 	bot.Listen()
 }

--- a/keybot/main.go
+++ b/keybot/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 
 	"github.com/keybase/slackbot"
 	"github.com/keybase/slackbot/launchd"
@@ -98,5 +99,8 @@ func main() {
 	bot.SetHelp(bot.HelpMessage() + "\n\n" + ext.Help(bot))
 
 	bot.SendMessage("I'm running.", os.Getenv("SLACK_CHANNEL"))
+	if runtime.GOOS == "windows" {
+		ext.Run(bot, os.Getenv("SLACK_CHANNEL"), []string{"startAutoTimer"})
+	}
 	bot.Listen()
 }

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -109,8 +110,6 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			}
 		}
 
-<<<<<<< Updated upstream
-=======
 		msg := fmt.Sprintf(autoBuild+"I'm starting the job `windows build`. To cancel run `!%s cancel`", bot.Name())
 		bot.SendMessage(msg, channel)
 
@@ -158,7 +157,6 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			return string(stdoutStderr), err
 		}
 
->>>>>>> Stashed changes
 		cmd := exec.Command(
 			"cmd", "/c",
 			path.Join(os.Getenv("GOPATH"), "src/github.com/keybase/client/packaging/windows/dorelease.cmd"),
@@ -248,8 +246,6 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			index = len(logContents) - 1000
 		}
 		bot.SendMessage(string(logContents[index:]), channel)
-<<<<<<< Updated upstream
-=======
 
 	case gitDiffCmd.FullCommand():
 		rawRepoText := *gitDiffRepo
@@ -293,7 +289,6 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 
 		bot.SendMessage(string(stdoutStderr), channel)
 
->>>>>>> Stashed changes
 	}
 	return cmd, nil
 }
@@ -305,8 +300,6 @@ func (d *winbot) Help(bot slackbot.Bot) string {
 	}
 	return out
 }
-<<<<<<< Updated upstream
-=======
 
 func Exists(name string) (bool, error) {
 	_, err := os.Stat(name)
@@ -345,4 +338,3 @@ func (d *winbot) winAutoBuild(bot slackbot.Bot, channel string) {
 		}
 	}
 }
->>>>>>> Stashed changes

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -57,7 +57,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 	logFileName := path.Join(os.TempDir(), "keybase.build.windows.log")
 
 	testAutoBuild := app.Command("testauto", "Simulate an automated daily build").Hidden()
-	startAutoTimer := app.Command("startAutoTimer", "Start the auto build timer").Hidden()
+	startAutoTimer := app.Command("startAutoTimer", "Start the auto build timer")
 
 	cmd, usage, cmdErr := cli.Parse(app, args, stringBuffer)
 	if usage != "" || cmdErr != nil {

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -48,6 +48,11 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 	cancel := app.Command("cancel", "Cancel current")
 
 	dumplogCmd := app.Command("dumplog", "Show the last log file")
+	gitDiffCmd := app.Command("gdiff", "Show the git diff")
+	gitDiffRepo := gitDiffCmd.Arg("repo", "Repo path relative to $GOPATH/src").Required().String()
+
+	gitCleanCmd := app.Command("gclean", "Clean the repo")
+	gitCleanRepo := gitCleanCmd.Arg("repo", "Repo path relative to $GOPATH/src").Required().String()
 
 	logFileName := path.Join(os.TempDir(), "keybase.build.windows.log")
 
@@ -160,7 +165,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 		cmd := exec.Command(
 			"cmd", "/c",
 			path.Join(os.Getenv("GOPATH"), "src/github.com/keybase/client/packaging/windows/dorelease.cmd"),
-			">",
+			">>",
 			logFileName,
 			"2>&1")
 		cmd.Env = append(os.Environ(),

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -43,7 +43,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 	buildWindowsKbfsCommit := buildWindows.Flag("kbfs-commit", "Build a specific kbfs commit").String()
 	buildWindowsSkipCI := buildWindows.Flag("skip-ci", "Whether to skip CI").Bool()
 	buildWindowsSmoke := buildWindows.Flag("smoke", "Build a smoke pair").Bool()
-	buildWindowsAuto := buildWindows.Flag("auto", "Specify build was triggered automatically").Bool().Hidden()
+	buildWindowsAuto := buildWindows.Flag("auto", "Specify build was triggered automatically").Hidden().Bool()
 
 	cancel := app.Command("cancel", "Cancel current")
 
@@ -173,8 +173,6 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			"TEST="+boolToEnvString(testBuild),
 			"AUTOMATED_BULD="+autoBuild,
 		)
-		msg := fmt.Sprintf("I'm starting the job `windows build`. To cancel run `!%s cancel`", bot.Name())
-		bot.SendMessage(msg, channel)
 
 		go func() {
 			err := cmd.Start()

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -317,16 +317,18 @@ func (d *winbot) winAutoBuild(bot slackbot.Bot, channel string) {
 	for {
 		hour := time.Now().Hour()
 		hour = ((24 - hour) + 7)
-		if time.Now().Weekday() == time.Friday {
+		next := time.Now().Add(time.Duration(hour))
+		if next.Weekday() == time.Saturday {
+			hour += 48
+		}
+		if next.Weekday() == time.Sunday {
 			hour += 24
 		}
-		if time.Now().Weekday() == time.Saturday {
-			hour += 24
-		}
+		next = time.Now().Add(time.Duration(hour))
 
 		args := []string{"build", "--auto"}
 
-		msg := fmt.Sprintf("Next automatic build in %d hours", hour)
+		msg := fmt.Sprintf("Next automatic build at %s", next.Format(time.RFC822))
 		bot.SendMessage(msg, channel)
 
 		select {

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -317,19 +317,19 @@ func (d *winbot) winAutoBuild(bot slackbot.Bot, channel string) {
 	for {
 		hour := time.Now().Hour()
 		hour = ((24 - hour) + 7)
-		next := time.Now().Add(time.Duration(hour))
+		next := time.Now().Add(time.Hour * time.Duration(hour))
 		if next.Weekday() == time.Saturday {
 			hour += 48
 		}
 		if next.Weekday() == time.Sunday {
 			hour += 24
 		}
-		next = time.Now().Add(time.Duration(hour))
-
-		args := []string{"build", "--auto"}
+		next = time.Now().Add(time.Hour * time.Duration(hour))
 
 		msg := fmt.Sprintf("Next automatic build at %s", next.Format(time.RFC822))
 		bot.SendMessage(msg, channel)
+
+		args := []string{"build", "--auto"}
 
 		select {
 		case <-d.testAuto:

--- a/keybot/winbot.go
+++ b/keybot/winbot.go
@@ -12,13 +12,16 @@ import (
 	"os/exec"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/keybase/slackbot"
 	"github.com/keybase/slackbot/cli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
-type winbot struct{}
+type winbot struct {
+	testAuto chan struct{}
+}
 
 const numLogLines = 10
 
@@ -39,6 +42,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 	buildWindowsKbfsCommit := buildWindows.Flag("kbfs-commit", "Build a specific kbfs commit").String()
 	buildWindowsSkipCI := buildWindows.Flag("skip-ci", "Whether to skip CI").Bool()
 	buildWindowsSmoke := buildWindows.Flag("smoke", "Build a smoke pair").Bool()
+	buildWindowsAuto := buildWindows.Flag("auto", "Specify build was triggered automatically").Bool().Hidden()
 
 	cancel := app.Command("cancel", "Cancel current")
 
@@ -46,9 +50,26 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 
 	logFileName := path.Join(os.TempDir(), "keybase.build.windows.log")
 
+	testAutoBuild := app.Command("testauto", "Simulate an automated daily build").Hidden()
+	startAutoTimer := app.Command("startAutoTimer", "Start the auto build timer").Hidden()
+
 	cmd, usage, cmdErr := cli.Parse(app, args, stringBuffer)
 	if usage != "" || cmdErr != nil {
 		return usage, cmdErr
+	}
+
+	// do these regardless of dry run status
+	if cmd == testAutoBuild.FullCommand() {
+		d.testAuto <- struct{}{}
+		return "Sent test signal", nil
+	}
+
+	if cmd == startAutoTimer.FullCommand() {
+		if d.testAuto != nil {
+			return "Timer already running", nil
+		}
+		go d.winAutoBuild(bot, channel)
+		return "", nil
 	}
 
 	if bot.Config().DryRun() {
@@ -70,6 +91,10 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 		smokeTest := *buildWindowsSmoke
 		skipCI := *buildWindowsSkipCI
 		testBuild := *buildWindowsTest
+		var autoBuild string
+		if *buildWindowsAuto {
+			autoBuild = "Automatic Build: "
+		}
 
 		updateChannel := "None"
 		if testBuild {
@@ -84,6 +109,56 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			}
 		}
 
+<<<<<<< Updated upstream
+=======
+		msg := fmt.Sprintf(autoBuild+"I'm starting the job `windows build`. To cancel run `!%s cancel`", bot.Name())
+		bot.SendMessage(msg, channel)
+
+		os.Remove(logFileName)
+		logf, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return "Unable to open logfile", err
+		}
+
+		gitCmd := exec.Command(
+			"git.exe",
+			"checkout",
+			"master",
+		)
+		gitCmd.Dir = os.ExpandEnv("$GOPATH/src/github.com/keybase/client")
+		stdoutStderr, err := gitCmd.CombinedOutput()
+		logf.Write(stdoutStderr)
+		if err != nil {
+			logf.Close()
+			return string(stdoutStderr), err
+		}
+
+		gitCmd = exec.Command(
+			"git.exe",
+			"pull",
+		)
+		gitCmd.Dir = os.ExpandEnv("$GOPATH/src/github.com/keybase/client")
+		stdoutStderr, err = gitCmd.CombinedOutput()
+		logf.Write(stdoutStderr)
+		if err != nil {
+			logf.Close()
+			return string(stdoutStderr), err
+		}
+
+		gitCmd = exec.Command(
+			"git.exe",
+			"checkout",
+			*buildWindowsCientCommit,
+		)
+		gitCmd.Dir = os.ExpandEnv("$GOPATH/src/github.com/keybase/client")
+		stdoutStderr, err = gitCmd.CombinedOutput()
+		logf.Write(stdoutStderr)
+		logf.Close()
+		if err != nil {
+			return string(stdoutStderr), err
+		}
+
+>>>>>>> Stashed changes
 		cmd := exec.Command(
 			"cmd", "/c",
 			path.Join(os.Getenv("GOPATH"), "src/github.com/keybase/client/packaging/windows/dorelease.cmd"),
@@ -98,6 +173,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			"SlackBot=1",
 			"SMOKE_TEST="+boolToEnvString(smokeTest),
 			"TEST="+boolToEnvString(testBuild),
+			"AUTOMATED_BULD="+autoBuild,
 		)
 		msg := fmt.Sprintf("I'm starting the job `windows build`. To cancel run `!%s cancel`", bot.Name())
 		bot.SendMessage(msg, channel)
@@ -120,9 +196,9 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 				"--bucket-name="+bucketName,
 				"--path="+logFileName,
 			)
-			resultMsg := "Finished the job `windows build`"
+			resultMsg := autoBuild + "Finished the job `windows build`"
 			if err != nil {
-				resultMsg = "Error in job `windows build`"
+				resultMsg = autoBuild + "Error in job `windows build`"
 				var lines [numLogLines]string
 				// Send a log snippet too
 				index := 0
@@ -130,7 +206,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 
 				f, err := os.Open(logFileName)
 				if err != nil {
-					bot.SendMessage("Error reading "+logFileName+": "+err.Error(), channel)
+					bot.SendMessage(autoBuild+"Error reading "+logFileName+": "+err.Error(), channel)
 				}
 
 				scanner := bufio.NewScanner(f)
@@ -139,7 +215,7 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 					lineCount += 1
 				}
 				if err := scanner.Err(); err != nil {
-					bot.SendMessage("Error scanning "+logFileName+": "+err.Error(), channel)
+					bot.SendMessage(autoBuild+"Error scanning "+logFileName+": "+err.Error(), channel)
 				}
 				if lineCount > numLogLines {
 					index = lineCount % numLogLines
@@ -172,6 +248,52 @@ func (d *winbot) Run(bot slackbot.Bot, channel string, args []string) (string, e
 			index = len(logContents) - 1000
 		}
 		bot.SendMessage(string(logContents[index:]), channel)
+<<<<<<< Updated upstream
+=======
+
+	case gitDiffCmd.FullCommand():
+		rawRepoText := *gitDiffRepo
+		repoParsed := strings.Split(strings.Trim(rawRepoText, "`<>"), "|")[1]
+
+		gitDiffCmd := exec.Command(
+			"git.exe",
+			"diff",
+		)
+		gitDiffCmd.Dir = os.ExpandEnv(path.Join("$GOPATH/src", repoParsed))
+
+		if exists, err := Exists(path.Join(gitDiffCmd.Dir, ".git")); !exists {
+			return "Not a git repo", err
+		}
+
+		stdoutStderr, err := gitDiffCmd.CombinedOutput()
+		if err != nil {
+			return "Error", err
+		}
+		bot.SendMessage(string(stdoutStderr), channel)
+
+	case gitCleanCmd.FullCommand():
+		rawRepoText := *gitCleanRepo
+		repoParsed := strings.Split(strings.Trim(rawRepoText, "`<>"), "|")[1]
+
+		gitCleanCmd := exec.Command(
+			"git.exe",
+			"clean",
+			"-f",
+		)
+		gitCleanCmd.Dir = os.ExpandEnv(path.Join("$GOPATH/src", repoParsed))
+
+		if exists, err := Exists(path.Join(gitCleanCmd.Dir, ".git")); !exists {
+			return "Not a git repo", err
+		}
+
+		stdoutStderr, err := gitCleanCmd.CombinedOutput()
+		if err != nil {
+			return "Error", err
+		}
+
+		bot.SendMessage(string(stdoutStderr), channel)
+
+>>>>>>> Stashed changes
 	}
 	return cmd, nil
 }
@@ -183,3 +305,44 @@ func (d *winbot) Help(bot slackbot.Bot) string {
 	}
 	return out
 }
+<<<<<<< Updated upstream
+=======
+
+func Exists(name string) (bool, error) {
+	_, err := os.Stat(name)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err != nil, err
+}
+
+func (d *winbot) winAutoBuild(bot slackbot.Bot, channel string) {
+	d.testAuto = make(chan struct{})
+	for {
+		hour := time.Now().Hour()
+		hour = ((24 - hour) + 7)
+		if time.Now().Weekday() == time.Friday {
+			hour += 24
+		}
+		if time.Now().Weekday() == time.Saturday {
+			hour += 24
+		}
+
+		args := []string{"build", "--auto"}
+
+		msg := fmt.Sprintf("Next automatic build in %d hours", hour)
+		bot.SendMessage(msg, channel)
+
+		select {
+		case <-d.testAuto:
+		case <-time.After(time.Duration(hour) * time.Hour):
+			args = append(args, "--smoke")
+		}
+		message, err := d.Run(bot, channel, args)
+		if err != nil {
+			msg := fmt.Sprintf("AutoBuild ERROR -- %s: %s", message, err.Error())
+			bot.SendMessage(msg, channel)
+		}
+	}
+}
+>>>>>>> Stashed changes


### PR DESCRIPTION
There are lots of good tools for running scheduled tasks on Windows, but we have a serious restriction that the saltpack signing passphrase not persist anywhere except typed into an environment variable in a cmd window at startup. So this seemed easiest. It will also be easier to add bot commands to adjust timing if we want.
Note the timer has to be started manually, since there likely will be 2 bots active.
Also: this has some git commands from another PR that got tangled with this one and was never reviewed.
@maxtaco @keybase/react-hackers 