### PR TITLE
When building off a given commit, add --smoke to allow creating a smoke pair

### DIFF
--- a/keybot/darwinbot.go
+++ b/keybot/darwinbot.go
@@ -60,7 +60,7 @@ func (d *darwinbot) Run(bot slackbot.Bot, channel string, args []string) (string
 		smokeTest := true
 		skipCI := *buildDarwinSkipCI
 		testBuild := *buildDarwinTest
-		// Don't smoke, wait for CI or promote test if custom build
+		// If it's a custom build, make it a test build unless --smoke is passed.
 		if *buildDarwinClientCommit != "" || *buildDarwinKbfsCommit != "" {
 			smokeTest = *buildDarwinSmoke
 			skipCI = *buildDarwinSkipCI

--- a/keybot/darwinbot.go
+++ b/keybot/darwinbot.go
@@ -63,7 +63,6 @@ func (d *darwinbot) Run(bot slackbot.Bot, channel string, args []string) (string
 		// If it's a custom build, make it a test build unless --smoke is passed.
 		if *buildDarwinClientCommit != "" || *buildDarwinKbfsCommit != "" {
 			smokeTest = *buildDarwinSmoke
-			skipCI = *buildDarwinSkipCI
 			testBuild = !*buildDarwinSmoke
 		}
 		script := launchd.Script{

--- a/keybot/darwinbot.go
+++ b/keybot/darwinbot.go
@@ -26,9 +26,10 @@ func (d *darwinbot) Run(bot slackbot.Bot, channel string, args []string) (string
 
 	buildDarwin := build.Command("darwin", "Start a darwin build")
 	buildDarwinTest := buildDarwin.Flag("test", "Whether build is for testing").Bool()
-	buildDarwinCientCommit := buildDarwin.Flag("client-commit", "Build a specific client commit").String()
+	buildDarwinClientCommit := buildDarwin.Flag("client-commit", "Build a specific client commit").String()
 	buildDarwinKbfsCommit := buildDarwin.Flag("kbfs-commit", "Build a specific kbfs commit").String()
 	buildDarwinSkipCI := buildDarwin.Flag("skip-ci", "Whether to skip CI").Bool()
+	buildDarwinSmoke := buildDarwin.Flag("smoke", "Whether to make a pair of builds for smoketesting when on a branch").Bool()
 
 	cancel := app.Command("cancel", "Cancel")
 	cancelLabel := cancel.Arg("label", "Launchd job label").Required().String()
@@ -60,10 +61,10 @@ func (d *darwinbot) Run(bot slackbot.Bot, channel string, args []string) (string
 		skipCI := *buildDarwinSkipCI
 		testBuild := *buildDarwinTest
 		// Don't smoke, wait for CI or promote test if custom build
-		if *buildDarwinCientCommit != "" || *buildDarwinKbfsCommit != "" {
-			smokeTest = false
-			skipCI = true
-			testBuild = true
+		if *buildDarwinClientCommit != "" || *buildDarwinKbfsCommit != "" {
+			smokeTest = *buildDarwinSmoke
+			skipCI = *buildDarwinSkipCI
+			testBuild = !*buildDarwinSmoke
 		}
 		script := launchd.Script{
 			Label:      "keybase.build.darwin",
@@ -73,7 +74,7 @@ func (d *darwinbot) Run(bot slackbot.Bot, channel string, args []string) (string
 			EnvVars: []launchd.EnvVar{
 				launchd.EnvVar{Key: "SMOKE_TEST", Value: boolToEnvString(smokeTest)},
 				launchd.EnvVar{Key: "TEST", Value: boolToEnvString(testBuild)},
-				launchd.EnvVar{Key: "CLIENT_COMMIT", Value: *buildDarwinCientCommit},
+				launchd.EnvVar{Key: "CLIENT_COMMIT", Value: *buildDarwinClientCommit},
 				launchd.EnvVar{Key: "KBFS_COMMIT", Value: *buildDarwinKbfsCommit},
 				// TODO: Rename to SKIP_CI in packaging scripts
 				launchd.EnvVar{Key: "NOWAIT", Value: boolToEnvString(skipCI)},


### PR DESCRIPTION
@keybase/react-hackers 

After this PR, we have e.g.:
```
# make a single build, don't promote to admin channel
!darwinbot build darwin --client-commit f705a9510f4 --kbfs-commit 6d00d555 --test

# make dual smoke builds for release, promote to admin channel
!darwinbot build darwin --client-commit f705a9510f4 --kbfs-commit 6d00d555 --smoke
```