### PR TITLE
Allow promoting a release to specify which platform to promote on

### DIFF
--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -47,7 +47,9 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 
 	release := app.Command("release", "Release things")
 	releasePromote := release.Command("promote", "Promote a release to public")
+	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").String()
 	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").String()
+
 	releaseBroken := release.Command("broken", "Mark a release as broken")
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()
 
@@ -147,7 +149,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			Label:      "keybase.release.promote",
 			Path:       "github.com/keybase/slackbot/scripts/release.promote.sh",
 			BucketName: "prerelease.keybase.io",
-			Platform:   "darwin",
+			Platform:   *releaseToPromotePlatform,
 			EnvVars: []launchd.EnvVar{
 				launchd.EnvVar{Key: "RELEASE_TO_PROMOTE", Value: *releaseToPromote},
 			},

--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -47,6 +47,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 
 	release := app.Command("release", "Release things")
 	releasePromote := release.Command("promote", "Promote a release to public")
+	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").String()
 	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").String()
 	releaseBroken := release.Command("broken", "Mark a release as broken")
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()
@@ -147,9 +148,9 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			Label:      "keybase.release.promote",
 			Path:       "github.com/keybase/slackbot/scripts/release.promote.sh",
 			BucketName: "prerelease.keybase.io",
-			Platform:   "darwin",
 			EnvVars: []launchd.EnvVar{
 				launchd.EnvVar{Key: "RELEASE_TO_PROMOTE", Value: *releaseToPromote},
+				launchd.EnvVar{Key: "PLATFORM", Value: *releaseToPromotePlatform},
 			},
 		}
 		return runScript(bot, channel, env, script)

--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -47,7 +47,6 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 
 	release := app.Command("release", "Release things")
 	releasePromote := release.Command("promote", "Promote a release to public")
-	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").String()
 	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").String()
 	releaseBroken := release.Command("broken", "Mark a release as broken")
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()
@@ -148,9 +147,9 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			Label:      "keybase.release.promote",
 			Path:       "github.com/keybase/slackbot/scripts/release.promote.sh",
 			BucketName: "prerelease.keybase.io",
+			Platform:   "darwin",
 			EnvVars: []launchd.EnvVar{
 				launchd.EnvVar{Key: "RELEASE_TO_PROMOTE", Value: *releaseToPromote},
-				launchd.EnvVar{Key: "PLATFORM", Value: *releaseToPromotePlatform},
 			},
 		}
 		return runScript(bot, channel, env, script)

--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -47,8 +47,8 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 
 	release := app.Command("release", "Release things")
 	releasePromote := release.Command("promote", "Promote a release to public")
-	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").String()
-	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").String()
+	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").Required().String()
+	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").Required().String()
 
 	releaseBroken := release.Command("broken", "Mark a release as broken")
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()

--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -49,6 +49,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 	releasePromote := release.Command("promote", "Promote a release to public")
 	releaseToPromotePlatform := releasePromote.Arg("platform", "Platform to promote a release for").Required().String()
 	releaseToPromote := releasePromote.Arg("release-to-promote", "Promote a specific release to public immediately").Required().String()
+	releaseToPromoteDryRun := releasePromote.Flag("dry-run", "Announce what would be done without doing it").Bool()
 
 	releaseBroken := release.Command("broken", "Mark a release as broken")
 	releaseBrokenVersion := releaseBroken.Arg("version", "Mark a release as broken").Required().String()
@@ -152,6 +153,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			Platform:   *releaseToPromotePlatform,
 			EnvVars: []launchd.EnvVar{
 				launchd.EnvVar{Key: "RELEASE_TO_PROMOTE", Value: *releaseToPromote},
+				launchd.EnvVar{Key: "DRY_RUN", Value: boolToString(*releaseToPromoteDryRun)},
 			},
 		}
 		return runScript(bot, channel, env, script)

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -43,7 +43,15 @@ func TestPromoteRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}}" {
+	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}, launchd.EnvVar{Key:\"DRY_RUN\", Value:\"false\"}}" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+
+	out, err = ext.Run(bot, "", []string{"release", "promote", "darwin", "1.2.3", "--dry-run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}, launchd.EnvVar{Key:\"DRY_RUN\", Value:\"true\"}}" {
 		t.Errorf("Unexpected output: %s", out)
 	}
 }

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -39,11 +39,11 @@ func TestPromoteRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	ext := &keybot{}
-	out, err := ext.Run(bot, "", []string{"release", "promote", "1.2.3"})
+	out, err := ext.Run(bot, "", []string{"release", "promote", "darwin", "1.2.3"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}}" {
+	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}, launchd.EnvVar{Key:\"PLATFORM\", Value:\"darwin\"}}" {
 		t.Errorf("Unexpected output: %s", out)
 	}
 }

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -39,7 +39,7 @@ func TestPromoteRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	ext := &keybot{}
-	out, err := ext.Run(bot, "", []string{"release", "promote", "1.2.3"})
+	out, err := ext.Run(bot, "", []string{"release", "promote", "darwin", "1.2.3"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/keybot/main_test.go
+++ b/keybot/main_test.go
@@ -39,11 +39,11 @@ func TestPromoteRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	ext := &keybot{}
-	out, err := ext.Run(bot, "", []string{"release", "promote", "darwin", "1.2.3"})
+	out, err := ext.Run(bot, "", []string{"release", "promote", "1.2.3"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}, launchd.EnvVar{Key:\"PLATFORM\", Value:\"darwin\"}}" {
+	if out != "I would have run a launchd job (keybase.release.promote)\nPath: \"github.com/keybase/slackbot/scripts/release.promote.sh\"\nEnvVars: []launchd.EnvVar{launchd.EnvVar{Key:\"RELEASE_TO_PROMOTE\", Value:\"1.2.3\"}}" {
 		t.Errorf("Unexpected output: %s", out)
 	}
 }

--- a/scripts/release.promote.sh
+++ b/scripts/release.promote.sh
@@ -9,8 +9,13 @@ echo "Loading release tool"
 "$dir/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
+dryrun=""
+if [ $DRY_RUN == 'true' ]; then
+  dryrun="--dry-run"
+fi
+
 if [ -n "$RELEASE_TO_PROMOTE" ]; then
-  "$release_bin" promote-a-release --release="$RELEASE_TO_PROMOTE" --bucket-name="$BUCKET_NAME" --platform="$PLATFORM"
+  "$release_bin" promote-a-release --release="$RELEASE_TO_PROMOTE" --bucket-name="$BUCKET_NAME" --platform="$PLATFORM" $dryrun
   "$dir/send.sh" "Promoted $PLATFORM release $RELEASE_TO_PROMOTE ($BUCKET_NAME)"
 else
   "$release_bin" promote-releases --bucket-name="$BUCKET_NAME" --platform="$PLATFORM"

--- a/scripts/release.promote.sh
+++ b/scripts/release.promote.sh
@@ -18,6 +18,10 @@ if [ -n "$RELEASE_TO_PROMOTE" ]; then
   "$release_bin" promote-a-release --release="$RELEASE_TO_PROMOTE" --bucket-name="$BUCKET_NAME" --platform="$PLATFORM" $dryrun
   "$dir/send.sh" "Promoted $PLATFORM release $RELEASE_TO_PROMOTE ($BUCKET_NAME)"
 else
+  if [ $DRY_RUN == 'true' ]; then
+    "$dir/send.sh" "Can't dry-run without a specific release to promote"
+    exit 1
+  fi
   "$release_bin" promote-releases --bucket-name="$BUCKET_NAME" --platform="$PLATFORM"
   "$dir/send.sh" "Promoted $PLATFORM release on ($BUCKET_NAME)"
 fi


### PR DESCRIPTION
r? @mlsteele CC @keybase/picnicsquad 

Here's the Slackbot (actually launchd) side of keybase/release#31.

The launchd script itself was already taking a $PLATFORM env var, so it actually needs no modifications.  It's just that $PLATFORM was hardcoded to darwin before and now it isn't.