### PR TITLE
keybot: skip timed builds of already-built commits

### DIFF
--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -165,7 +165,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			},
 		}
 		env.GoPath = env.PathFromHome("go-ios")
-		return runScript(bot, channel, env, script, *ignorePause)
+		return runBuildScript(bot, channel, env, script, *ignorePause, automated, *buildMobileCientCommit)
 
 	case buildAndroid.FullCommand():
 		// --skip-ci is always on; flag value is ignored.
@@ -186,7 +186,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			},
 		}
 		env.GoPath = env.PathFromHome("go-android") // Custom go path for Android so we don't conflict
-		return runScript(bot, channel, env, script, *ignorePause)
+		return runBuildScript(bot, channel, env, script, *ignorePause, automated, *buildAndroidCientCommit)
 
 	case buildIOS.FullCommand():
 		// --skip-ci is always on; flag value is ignored.
@@ -206,7 +206,7 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 			},
 		}
 		env.GoPath = env.PathFromHome("go-ios") // Custom go path for iOS so we don't conflict
-		return runScript(bot, channel, env, script, *ignorePause)
+		return runBuildScript(bot, channel, env, script, *ignorePause, automated, *buildIOSCientCommit)
 
 	case releasePromote.FullCommand():
 		script := launchd.Script{

--- a/keybot/lastbuild.go
+++ b/keybot/lastbuild.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -22,11 +21,11 @@ const clientRepoURL = "https://github.com/keybase/client.git"
 // automated build for a job. run.sh writes it when the build script finishes
 // successfully.
 func lastBuildPath(label string) (string, error) {
-	currentUser, err := user.Current()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(currentUser.HomeDir, ".keybot.lastbuild."+label), nil
+	return filepath.Join(home, ".keybot.lastbuild."+label), nil
 }
 
 func readLastBuiltCommit(path string) string {
@@ -47,7 +46,7 @@ func currentClientCommit(clientCommit string) (string, error) {
 	//nolint:gosec,noctx // git is a trusted system binary with safe arguments, no context available
 	out, err := exec.Command("git", "ls-remote", clientRepoURL, "HEAD").Output()
 	if err != nil {
-		return "", fmt.Errorf("Error in git ls-remote: %s", err)
+		return "", fmt.Errorf("Error in git ls-remote: %w", err)
 	}
 	fields := strings.Fields(string(out))
 	if len(fields) == 0 {
@@ -82,9 +81,24 @@ func runBuildScript(bot *slackbot.Bot, channel string, env launchd.Env, script l
 		return fmt.Sprintf("I already did an automated build of `%s` for commit `%s`, so I'm skipping this one.", script.Label, commit), nil
 	}
 
+	// Pin the build to the resolved commit so the state file can't record a
+	// different commit than was built if remote HEAD moves before the build
+	// script fetches.
+	script.EnvVars = setEnvVar(script.EnvVars, "CLIENT_COMMIT", commit)
 	script.EnvVars = append(script.EnvVars,
 		launchd.EnvVar{Key: "AUTOMATED_BUILD_COMMIT", Value: commit},
 		launchd.EnvVar{Key: "AUTOMATED_BUILD_COMMIT_PATH", Value: statePath},
 	)
 	return runScript(bot, channel, env, script, ignorePause)
+}
+
+// setEnvVar replaces the value of key in envVars, appending it if not present.
+func setEnvVar(envVars []launchd.EnvVar, key string, value string) []launchd.EnvVar {
+	for i := range envVars {
+		if envVars[i].Key == key {
+			envVars[i].Value = value
+			return envVars
+		}
+	}
+	return append(envVars, launchd.EnvVar{Key: key, Value: value})
 }

--- a/keybot/lastbuild.go
+++ b/keybot/lastbuild.go
@@ -1,0 +1,90 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/keybase/slackbot"
+	"github.com/keybase/slackbot/launchd"
+)
+
+const clientRepoURL = "https://github.com/keybase/client.git"
+
+// lastBuildPath is the file holding the commit of the last successful
+// automated build for a job. run.sh writes it when the build script finishes
+// successfully.
+func lastBuildPath(label string) (string, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(currentUser.HomeDir, ".keybot.lastbuild."+label), nil
+}
+
+func readLastBuiltCommit(path string) string {
+	fileBytes, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(fileBytes))
+}
+
+// currentClientCommit returns the commit an automated build would build: the
+// explicit client commit if one was given, otherwise the remote HEAD of the
+// client repo.
+func currentClientCommit(clientCommit string) (string, error) {
+	if clientCommit != "" {
+		return clientCommit, nil
+	}
+	//nolint:gosec,noctx // git is a trusted system binary with safe arguments, no context available
+	out, err := exec.Command("git", "ls-remote", clientRepoURL, "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("Error in git ls-remote: %s", err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("Empty output from git ls-remote")
+	}
+	return fields[0], nil
+}
+
+// runBuildScript runs a build like runScript, but automated (timed) builds
+// skip the build if the commit was already built for this job. Build numbers
+// auto increment now, so rebuilding the same commit would produce a duplicate
+// build. The commit is recorded by run.sh only after the build script
+// succeeds, so a failed build is retried on the next timed run.
+func runBuildScript(bot *slackbot.Bot, channel string, env launchd.Env, script launchd.Script, ignorePause bool, automated bool, clientCommit string) (string, error) {
+	if !automated || bot.Config().DryRun() || (bot.Config().Paused() && !ignorePause) {
+		return runScript(bot, channel, env, script, ignorePause)
+	}
+
+	statePath, err := lastBuildPath(script.Label)
+	if err != nil {
+		log.Printf("Couldn't get last build path for %s (%s), building anyway\n", script.Label, err)
+		return runScript(bot, channel, env, script, ignorePause)
+	}
+
+	commit, err := currentClientCommit(clientCommit)
+	if err != nil {
+		log.Printf("Couldn't determine client commit for %s (%s), building anyway\n", script.Label, err)
+		return runScript(bot, channel, env, script, ignorePause)
+	}
+
+	if commit == readLastBuiltCommit(statePath) {
+		return fmt.Sprintf("I already did an automated build of `%s` for commit `%s`, so I'm skipping this one.", script.Label, commit), nil
+	}
+
+	script.EnvVars = append(script.EnvVars,
+		launchd.EnvVar{Key: "AUTOMATED_BUILD_COMMIT", Value: commit},
+		launchd.EnvVar{Key: "AUTOMATED_BUILD_COMMIT_PATH", Value: statePath},
+	)
+	return runScript(bot, channel, env, script, ignorePause)
+}

--- a/keybot/lastbuild_test.go
+++ b/keybot/lastbuild_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keybase/slackbot"
+)
+
+func TestReadLastBuiltCommit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lastbuild")
+	if commit := readLastBuiltCommit(path); commit != "" {
+		t.Errorf("Expected empty commit for missing file, got %q", commit)
+	}
+	// run.sh writes the commit with a trailing newline.
+	if err := os.WriteFile(path, []byte("abc123\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if commit := readLastBuiltCommit(path); commit != "abc123" {
+		t.Errorf("Expected abc123, got %q", commit)
+	}
+}
+
+func TestCurrentClientCommitExplicit(t *testing.T) {
+	commit, err := currentClientCommit("abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commit != "abc123" {
+		t.Errorf("Expected explicit commit to be returned, got %s", commit)
+	}
+}
+
+func TestAutomatedFlagParses(t *testing.T) {
+	bot, err := slackbot.NewTestBot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext := &keybot{}
+	// Test bot is in dry run mode, so the dedupe check is bypassed and no
+	// network access or state file is needed.
+	out, err := ext.Run(bot, "", []string{"build", "ios", "--automated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "I would have run a launchd job (keybase.build.ios)") {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}
+
+func TestAutomatedPausedBlocksBuild(t *testing.T) {
+	bot := slackbot.NewBot(slackbot.NewConfig(false, true), "testbot", "", &slackbot.SlackBotBackend{})
+	ext := &keybot{}
+	out, err := ext.Run(bot, "", []string{"build", "mobile", "--automated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "I'm paused so I can't do that, but I would have run a launchd job (keybase.build.mobile)" {
+		t.Errorf("Unexpected output: %s", out)
+	}
+}

--- a/keybot/lastbuild_test.go
+++ b/keybot/lastbuild_test.go
@@ -10,7 +10,36 @@ import (
 	"testing"
 
 	"github.com/keybase/slackbot"
+	"github.com/keybase/slackbot/launchd"
 )
+
+func TestLastBuildPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := lastBuildPath("keybase.build.ios")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(home, ".keybot.lastbuild.keybase.build.ios")
+	if path != expected {
+		t.Errorf("Expected %q, got %q", expected, path)
+	}
+}
+
+func TestSetEnvVar(t *testing.T) {
+	envVars := []launchd.EnvVar{
+		{Key: "CLIENT_COMMIT", Value: ""},
+		{Key: "CHECK_CI", Value: "false"},
+	}
+	envVars = setEnvVar(envVars, "CLIENT_COMMIT", "abc123")
+	if len(envVars) != 2 || envVars[0].Value != "abc123" {
+		t.Errorf("Expected existing CLIENT_COMMIT replaced, got %+v", envVars)
+	}
+	envVars = setEnvVar(envVars, "NEW_KEY", "v")
+	if len(envVars) != 3 || envVars[2].Key != "NEW_KEY" || envVars[2].Value != "v" {
+		t.Errorf("Expected NEW_KEY appended, got %+v", envVars)
+	}
+}
 
 func TestReadLastBuiltCommit(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "lastbuild")

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -30,7 +30,8 @@ trap 'err_report $LINENO' ERR
 record_commit=${AUTOMATED_BUILD_COMMIT:-""}
 record_commit_path=${AUTOMATED_BUILD_COMMIT_PATH:-""}
 if [ -n "$record_commit" ] && [ -n "$record_commit_path" ]; then
-  echo "$record_commit" > "$record_commit_path"
+  # Best effort: failing to record the commit shouldn't fail a successful build.
+  echo "$record_commit" > "$record_commit_path" || echo "Warning: couldn't write $record_commit_path"
 fi
 
 if [ "$nolog" = "" ]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -25,6 +25,14 @@ trap 'err_report $LINENO' ERR
 
 "$SCRIPT_PATH"
 
+# Record the commit built by a successful automated build so the bot can skip
+# rebuilding it on the next timed run.
+record_commit=${AUTOMATED_BUILD_COMMIT:-""}
+record_commit_path=${AUTOMATED_BUILD_COMMIT_PATH:-""}
+if [ -n "$record_commit" ] && [ -n "$record_commit_path" ]; then
+  echo "$record_commit" > "$record_commit_path"
+fi
+
 if [ "$nolog" = "" ]; then
   url=`$release_bin save-log --bucket-name=$bucket_name --path=$logpath --noerr`
   "$dir/send.sh" "Finished \`$label\`, view log at $url"


### PR DESCRIPTION
Build numbers now auto increment instead of deriving from the git commit, so a timed automated build of an unchanged commit produces a duplicate build.

## Changes
- Automated (`--automated`) mobile/ios/android builds resolve the commit about to be built (explicit `--client-commit`, else `git ls-remote` HEAD of keybase/client) and skip the build if it matches the last successful automated build for that job.
- Last-built commit is stored per job label in `~/.keybot.lastbuild.<label>`.
- `run.sh` writes the commit file only after the build script succeeds, so a failed build is retried on the next timed run. The bot passes the commit and state path via `AUTOMATED_BUILD_COMMIT` / `AUTOMATED_BUILD_COMMIT_PATH` env vars; jobs without them (manual builds, darwin, winbot) are unaffected.
- If the commit can't be determined (e.g. network failure), the build proceeds anyway.
- Non-automated builds always build, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)