### PR TITLE
keybot: use system go for build jobs

### DIFF
--- a/keybot/keybot.go
+++ b/keybot/keybot.go
@@ -94,10 +94,8 @@ func (k *keybot) Run(bot *slackbot.Bot, channel string, args []string) (string, 
 	home := os.Getenv("HOME")
 	javaHome := "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home"
 	javaBin := javaHome + "/bin"
-	// need custom go to fix issue
-	goRoot := "/Users/build/code/go"
-	goBin := goRoot + "/bin"
-	path := goBin + ":" + javaBin + ":/sbin:/usr/sbin:/bin:/usr/local/bin:/usr/bin:/opt/homebrew/bin"
+	// Homebrew comes first so we get its go; /usr/local has a stale go install.
+	path := "/opt/homebrew/bin:" + javaBin + ":/sbin:/usr/sbin:/bin:/usr/local/bin:/usr/bin"
 	env := launchd.NewEnv(home, path)
 	androidHome := "/usr/local/opt/android-sdk"
 	// ndkVer65x := "23.1.7779620"


### PR DESCRIPTION
The PATH handed to every launchd build job prepended `/Users/build/code/go/bin`, pinning build jobs to a hand-built go (the comment just said "need custom go to fix issue"). This drops it so jobs use the system go.

`/opt/homebrew/bin` also has to move ahead of `/usr/local/bin`. The build box has:

- `/opt/homebrew/bin/go` — 1.27.1, maintained by `scripts/upgrade.sh` (`brew upgrade go`)
- `/usr/local/bin/go` and `/usr/local/go/bin/go` — 1.23.1, a stale golang.org pkg install

Homebrew was last in the list, so simply deleting the prefix would have quietly downgraded build jobs to 1.23.1. `/usr/local/bin` is kept, just demoted below homebrew, since other tooling may live there.

Verified with `go build ./...`, `go vet ./keybot/`, and `go test ./keybot/ ./launchd/`.

Not included, but worth a follow-up: `keybot/keybase.keybot.plist` (the bot's own plist, installed on the box by hand) has the same ordering, and `keybot/keybot.sh` runs `go install` under it — so the keybot binary itself is currently built with 1.23.1. Alternatively, removing `/usr/local/go` from the box would drop the ordering trap entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MK1NyLj3PgQZxH343GEde